### PR TITLE
Extracts the index number, if the dataset already has

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+# Specify your gem's spec
+gemspec

--- a/lib/scraperwiki/sqlite_save_info.rb
+++ b/lib/scraperwiki/sqlite_save_info.rb
@@ -168,10 +168,11 @@ module SQLiteMagic
     def makenewindex(idxname, unique_keys)
       istart = 0
       if idxname
-        mnum = re.search("(\d+)$", idxname)
-        if mnum
-          istart = int(mnum.group(1))
-        end
+        #mnum = re.search("(\d+)$", idxname)
+        #if mnum
+        #  istart = int(mnum.group(1))
+        #end
+        istart = idxname.match("(\d+)$").first.to_i rescue 0
       end
       for i in 0..10000
         newidxname = format("%s_index%d", @swdatatblname, istart+i)

--- a/scraperwiki.gemspec
+++ b/scraperwiki.gemspec
@@ -8,4 +8,7 @@ Gem::Specification.new do |s|
   s.email       = 'francis@scraperwiki.com'
   s.files       = ["lib/scraperwiki.rb", "lib/scraperwiki/sqlite_save_info.rb"]
   s.homepage    = 'http://rubygems.org/gems/scraperwiki'
+
+  s.add_dependency "httpclient"
+  s.add_dependency "sqlite3"
 end

--- a/test/test_save.rb
+++ b/test/test_save.rb
@@ -80,8 +80,27 @@ CREATE UNIQUE INDEX `animals_index0` on `animals` (`id`);}
     }
   end
 
+  def test_new_columns_with_new_keys
+    Dir.mktmpdir { |dir|
+      Dir.chdir dir
+      ScraperWiki.save_sqlite(['id'], {'id'=> 10, 'animal'=> 'fox', 'awesomeness'=> 23 }, table_name = "animals")
+      ScraperWiki.save_sqlite(['id'], {'id'=> 40, 'animal'=> 'kitten', 'awesomeness'=> 91, 'cuteness'=> 87 }, table_name = "animals")
+      ScraperWiki.close_sqlite
+      check_dump %Q{CREATE TABLE `animals` (`id` integer,`animal` text,`awesomeness` integer, `cuteness` integer);
+INSERT INTO "animals" VALUES(10,'fox',23,NULL);
+INSERT INTO "animals" VALUES(40,'kitten',91,87);
+CREATE UNIQUE INDEX `animals_index0` on `animals` (`id`);}
 
-
+      ## Now add new set of data
+      ScraperWiki.save_sqlite(['link'], {'link'=> "http://dummy.com/fox.html", 'animal'=> 'fox', 'meat'=> 50, "edible"=> "False" }, table_name = "animals")
+      ScraperWiki.close_sqlite
+      check_dump %Q{CREATE TABLE `animals` (`id` integer,`animal` text,`awesomeness` integer, `cuteness` integer, `link` text, `meat` integer, `edible` text);
+INSERT INTO "animals" VALUES(10,'fox',23,NULL,NULL,NULL,NULL);
+INSERT INTO "animals" VALUES(40,'kitten',91,87,NULL,NULL,NULL);
+INSERT INTO "animals" VALUES(NULL,'fox',NULL,NULL,'http://dummy.com/fox.html',50,'False');
+CREATE UNIQUE INDEX `animals_index1` on `animals` (`link`);}
+    }
+  end
 end
 
 


### PR DESCRIPTION
If the dataset already has index and the save function demands creating
a new set of indexes [ i.e. making a new index key], then this change
helps in doing so.
To support the claim, I have created a new test case simulating the
scenario.
- Whether we have to drop the previous index / not is something we will
  observe & accomodate
