### PR TITLE
[Bug] Changing Databases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 # require 'bundler/gem_tasks'
-require 'rake/testtask'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new do |t|
-    t.libs << 'test'
-end
+RSpec::Core::RakeTask.new(:spec)
 
-task :default => :test
+task :default => :spec

--- a/lib/scraperwiki.rb
+++ b/lib/scraperwiki.rb
@@ -68,7 +68,7 @@ module ScraperWiki
 
   # Set configuration settings (only used to set the DB name right now)
   def config=(config_hash)
-    @config ||= config_hash
+    @config = config_hash
   end
 
   # Get configuration settings

--- a/lib/scraperwiki.rb
+++ b/lib/scraperwiki.rb
@@ -66,9 +66,16 @@ module ScraperWiki
     end
   end
 
+  # Set configuration settings (only used to set the DB name right now)
   def config=(config_hash)
     @config ||= config_hash
   end
+
+  # Get configuration settings
+  def config
+    @config
+  end
+
   # Saves the provided data into a local database for this scraper. Data is upserted
   # into this table (inserted if it does not exist, updated if the unique keys say it
   # does).

--- a/lib/scraperwiki.rb
+++ b/lib/scraperwiki.rb
@@ -60,6 +60,10 @@ module ScraperWiki
           when Time
             # maintains existing ScraperWiki behaviour
             v.iso8601.sub(/([+-]00:00|Z)$/, '')
+          when true
+            1
+          when false
+            0
           else
             v
           end

--- a/lib/scraperwiki.rb
+++ b/lib/scraperwiki.rb
@@ -66,9 +66,13 @@ module ScraperWiki
     end
   end
 
-  # Set configuration settings (only used to set the DB name right now)
+  # Set configuration settings and switch the DB if it's been set
   def config=(config_hash)
     @config = config_hash
+
+    if config_hash.is_a?(Hash) && config[:db]
+      sqlite_magic_connection(true)
+    end
   end
 
   # Get configuration settings
@@ -180,9 +184,13 @@ module ScraperWiki
   end
 
   # Establish an SQLiteMagic::Connection (and remember it)
-  def sqlite_magic_connection
+  def sqlite_magic_connection(reestablish = false)
     db = @config ? @config[:db] : 'scraperwiki.sqlite'
-    @sqlite_magic_connection ||= SqliteMagic::Connection.new(db)
-  end
 
+    if reestablish
+      @sqlite_magic_connection = SqliteMagic::Connection.new(db)
+    else
+      @sqlite_magic_connection ||= SqliteMagic::Connection.new(db)
+    end
+  end
 end

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -67,6 +67,12 @@ describe ScraperWiki do
       ScraperWiki.sqlite_magic_connection
     end
 
+    it 'should change the connection if the configuration changes' do
+      SqliteMagic::Connection.should_receive(:new).with('scraperwiki.sqlite').and_return(@dummy_sqlite_magic_connection)
+      ScraperWiki.sqlite_magic_connection
+      SqliteMagic::Connection.should_receive(:new).with('/some/location/of/sqlite_file.db').and_return(@dummy_sqlite_magic_connection)
+      ScraperWiki.config = {:db => '/some/location/of/sqlite_file.db'}
+    end
   end
 
   describe '#select' do

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -64,11 +64,12 @@ describe ScraperWiki do
       ScraperWiki.sqlite_magic_connection
     end
 
-    it 'should change the connection if the configuration changes' do
+    it 'should change the connection if the configuration has changed' do
       SqliteMagic::Connection.should_receive(:new).with('scraperwiki.sqlite').and_return(@dummy_sqlite_magic_connection)
       ScraperWiki.sqlite_magic_connection
       SqliteMagic::Connection.should_receive(:new).with('/some/location/of/sqlite_file.db').and_return(@dummy_sqlite_magic_connection)
       ScraperWiki.config = {:db => '/some/location/of/sqlite_file.db'}
+      ScraperWiki.sqlite_magic_connection
     end
   end
 

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -51,9 +51,12 @@ describe ScraperWiki do
     end
 
     context 'and config set' do
+      before do
+        ScraperWiki.config = {:db => '/some/location/of/sqlite_file.db'}
+      end
+
       it 'should get an SqliteMagic::Connection with db set in config' do
         SqliteMagic::Connection.should_receive(:new).with('/some/location/of/sqlite_file.db').and_return(@dummy_sqlite_magic_connection)
-        ScraperWiki.config = {:db => '/some/location/of/sqlite_file.db'}
         ScraperWiki.sqlite_magic_connection
       end
     end

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -19,6 +19,12 @@ describe ScraperWiki do
       ScraperWiki.config = :some_config
       ScraperWiki.instance_variable_get(:@config).should == :some_config
     end
+
+    it "should allow us to change the db setting" do
+      ScraperWiki.config = {db: "a_sqllite_db.sqlite"}
+      ScraperWiki.config = {db: "another_sqllite_db.sqlite"}
+      ScraperWiki.instance_variable_get(:@config).should == {db: "another_sqllite_db.sqlite"}
+    end
   end
 
   describe "#config" do

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -19,7 +19,13 @@ describe ScraperWiki do
       ScraperWiki.config = :some_config
       ScraperWiki.instance_variable_get(:@config).should == :some_config
     end
+  end
 
+  describe "#config" do
+    it "should return the configuration settings" do
+      ScraperWiki.config = :some_config
+      ScraperWiki.config == :some_config
+    end
   end
 
   describe 'sqlite_magic_connection' do

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -51,12 +51,9 @@ describe ScraperWiki do
     end
 
     context 'and config set' do
-      before do
-        ScraperWiki.config = {:db => '/some/location/of/sqlite_file.db'}
-      end
-
       it 'should get an SqliteMagic::Connection with db set in config' do
         SqliteMagic::Connection.should_receive(:new).with('/some/location/of/sqlite_file.db').and_return(@dummy_sqlite_magic_connection)
+        ScraperWiki.config = {:db => '/some/location/of/sqlite_file.db'}
         ScraperWiki.sqlite_magic_connection
       end
     end

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -283,6 +283,10 @@ describe ScraperWiki do
         expected_result = [{:foo => 'bar', :date_val => date.iso8601, :time_val => time.utc.iso8601.sub(/([+-]00:00|Z)$/, ''), :datetime_val => datetime.to_s}]
         ScraperWiki.convert_data(values_hash).should == expected_result
       end
+
+      it "should convert booleans to integers" do
+        ScraperWiki.convert_data({:true => true, :false => false}).should == [{:true => 1, :false => 0}]
+      end
     end
 
     context 'and passed an array of hashes' do
@@ -297,6 +301,10 @@ describe ScraperWiki do
         values_array = [{:foo => 'bar', :date_val => date}, {:time_val => time, :datetime_val => datetime}]
         expected_result = [{:foo => 'bar', :date_val => date.iso8601}, {:time_val => time.utc.iso8601.sub(/([+-]00:00|Z)$/,''), :datetime_val => datetime.to_s}]
         ScraperWiki.convert_data(values_array).should == expected_result
+      end
+
+      it "should convert booleans to integers" do
+        ScraperWiki.convert_data([{:true => true}, {:false => false}]).should == [{:true => 1}, {:false => 0}]
       end
     end
   end

--- a/spec/scraperwiki_spec.rb
+++ b/spec/scraperwiki_spec.rb
@@ -22,9 +22,17 @@ describe ScraperWiki do
   end
 
   describe "#config" do
-    it "should return the configuration settings" do
-      ScraperWiki.config = :some_config
-      ScraperWiki.config == :some_config
+    context "configuration settings are set" do
+      it "should return the configuration settings" do
+        ScraperWiki.config = :some_config
+        ScraperWiki.config == :some_config
+      end
+    end
+
+    context "no configuration settings set" do
+      it "should return blank configuration settings" do
+        ScraperWiki.config == nil
+      end
     end
   end
 


### PR DESCRIPTION
So I wanted, and expect to be able to, do this:

``` ruby
ScraperWiki.config = {db: 'some.db'}
ScraperWiki.select('* from swdata') # Gets data from some.db
ScraperWiki.config = {db: 'some_other.db'}
ScraperWiki.select('* from swdata') # Still gets data from some.db. Umm, whut?
```

but to my surprise the second query still gets data from the first one! This pull request allows the above behaviour, shouldn't change the API and, for bonus points:
- Actually runs the tests when you run `rake` - Travis will be happy!
- Allows us to read the configuration settings with `ScraperWiki.config`
